### PR TITLE
Update evaluate_model instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ logs/
 
 # PyPI
 .pypirc
+
+# Outputs
+results/
+tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.5.3]
+## [0.5.3-pre]
 Address obstacles to running `evaluate_model.py`:
 - Update the README command and installation instructions.
 - Update `inference` dependencies to "lighteval" instead of "lighteval[accelerate]" to reflect the fact that `accelerate` is now a main rather than optional dependency of `lighteval`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
 ## [0.5.3-pre]
-Address obstacles to running `evaluate_model.py`:
-- Update the README command and installation instructions.
-- Update `inference` dependencies to "lighteval" instead of "lighteval[accelerate]" to reflect the fact that `accelerate` is now a main rather than optional dependency of `lighteval`.
-- Fix import path passed to `lighteval/tasks/registry.py`.
-- Provide `--override-bs` as a CLI parameter as an alternative to automatic batch size selection, which does not work well on all hardware.
+- Improve process of running `evaluate_model.py`:
+  - Update the README command and installation instructions.
+  - Update `inference` dependencies to "lighteval" instead of "lighteval[accelerate]" to reflect the fact that `accelerate` is now a main rather than optional dependency of `lighteval`.
+  - Fix import path passed to `lighteval/tasks/registry.py`.
+  - Provide `--override-bs` as a CLI parameter as an alternative to automatic batch size selection, which does not work well on all hardware.
+  - Use available accelerators.
 
 ## [0.5.2]
 - Bump latex2sympy2_extended to 1.0.6, which fixes a bug with boxed normalization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.5.3]
+Address obstacles to running `evaluate_model.py`:
+- Update the README command and installation instructions.
+- Update `inference` dependencies to "lighteval" instead of "lighteval[accelerate]" to reflect the fact that `accelerate` is now a main rather than optional dependency of `lighteval`.
+- Fix import path passed to `lighteval/tasks/registry.py`.
+- Provide `--override-bs` as a CLI parameter as an alternative to automatic batch size selection, which does not work well on all hardware.
+
 ## [0.5.2]
 - Bump latex2sympy2_extended to 1.0.6, which fixes a bug with boxed normalization
 - Allow more separators in latex expressions

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ pip install 'math-verify[inference]'
 
 Run the following command to evaluate a model:
 ```bash
-python evaluate_model.py --model <model_name> (Qwen/Qwen2.5-72B-Instruct) --use_chat_template (True) --task <task_name> (math_hard)
+python evaluate_model.py --model <model_name> (HuggingFaceTB/SmolLM2-135M) --use_chat_template (True) --task <task_name> (amc23)
 ```
 
 Lastly if you want to only extract the answers from model outputs, you can run the following command:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If you want to evaluate a model from ground up, we have provided a script for en
 
 This script requires the optional "inference" dependencies to be installed, e.g. as follows:
 ```bash
-pip install math-verify[inference]
+pip install 'math-verify[inference]'
 ```
 
 Run the following command to evaluate a model:

--- a/README.md
+++ b/README.md
@@ -83,9 +83,14 @@ If you want to evaluate a model from ground up, we have provided a script for en
 - AMC23
 - AIME24
 
+This script requires the optional "inference" dependencies to be installed, e.g. as follows:
+```bash
+pip install math-verify[inference]
+```
+
 Run the following command to evaluate a model:
 ```bash
-python evaluate_model.py --model_name <model_name> (Qwen/Qwen2.5-72B-Instruct) --use_chat_template (True) --dataset <dataset_name> (math_hard)
+python evaluate_model.py --model <model_name> (Qwen/Qwen2.5-72B-Instruct) --use_chat_template (True) --task <task_name> (math_hard)
 ```
 
 Lastly if you want to only extract the answers from model outputs, you can run the following command:

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 import argparse
+from pathlib import Path
 from lighteval.logging.evaluation_tracker import EvaluationTracker
 from lighteval.models.transformers.transformers_model import TransformersModelConfig
 from lighteval.pipeline import ParallelismManager, Pipeline, PipelineParameters
@@ -42,7 +43,7 @@ def main() -> None:
     pipeline_params = PipelineParameters(
         launcher_type=ParallelismManager.ACCELERATE,
         max_samples=1000,
-        custom_tasks_directory="./math_verify/tasks.py",
+        custom_tasks_directory=Path(__file__).parent / "src/math_verify/tasks.py",
         env_config=EnvConfig(cache_dir="tmp/"),
         override_batch_size=-1
     )

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -45,7 +45,7 @@ def main() -> None:
     pipeline_params = PipelineParameters(
         launcher_type=ParallelismManager.ACCELERATE,
         max_samples=1000,
-        custom_tasks_directory=Path(__file__).parent / "src/math_verify/tasks.py",
+        custom_tasks_directory="math_verify.tasks",
         env_config=EnvConfig(cache_dir="tmp/"),
         override_batch_size=args.override_bs,
     )

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -27,6 +27,8 @@ def parse_args() -> argparse.Namespace:
                        help='Model name or path')
     parser.add_argument('--use_chat_template', action='store_true', default=False,
                        help='Use chat template')
+    parser.add_argument('--override_bs', type=int, default=-1,
+                       help='Batch size; -1 for automatic batch size')
     return parser.parse_args()
 
 
@@ -45,7 +47,7 @@ def main() -> None:
         max_samples=1000,
         custom_tasks_directory=Path(__file__).parent / "src/math_verify/tasks.py",
         env_config=EnvConfig(cache_dir="tmp/"),
-        override_batch_size=-1
+        override_batch_size=args.override_bs,
     )
 
     model_config = TransformersModelConfig(

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -54,7 +54,6 @@ def main() -> None:
         pretrained=args.model,
         dtype="bfloat16",
         use_chat_template=args.use_chat_template,
-        accelerator=accelerator,
     )
 
     pipeline = Pipeline(

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -54,6 +54,7 @@ def main() -> None:
         pretrained=args.model,
         dtype="bfloat16",
         use_chat_template=args.use_chat_template,
+        accelerator=accelerator,
     )
 
     pipeline = Pipeline(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "math-verify"
-version = "0.5.3"
+version = "0.5.2"
 description = "A library for verifying mathematical answers"
 authors = [
     { name = "Hynek Kydlíček", email = "hynek.kydlicek@huggingface.co" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 inference = [
-    "lighteval[accelerate]",
+    "lighteval",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "math-verify"
-version = "0.5.2"
+version = "0.5.3"
 description = "A library for verifying mathematical answers"
 authors = [
     { name = "Hynek Kydlíček", email = "hynek.kydlicek@huggingface.co" }


### PR DESCRIPTION
Addresses the following obstacles to running `evaluate_model.py`:

1. The CLI parameters in the README command are incorrect.
2. The dataset in that command has been taken down (https://huggingface.co/datasets/hendrycks/competition_math/discussions/5).
3. The model in that command is ginormous; it might be better to suggest a small model for folks who are just getting started.
4. The README does not mention the need to install the optional "inference" dependencies.
5. Those inference dependencies include "lighteval[accelerate]", but `accelerate` is now a main rather than optional dependency of `lighteval`.
6. https://github.com/huggingface/Math-Verify/blob/main/evaluate_model.py#L45 gives a relative path, which leads to an error when `lighteval/tasks/registry.py` passes it into `importlib.import_module` without specifying a package; moreover, the relative path it gives is wrong.
7. It tries to select a batch size automatically, which seems to stall on my M1 MacBook; this PR provides a workaround by adding `--override-bs` as a CLI parameter.