### PR TITLE
[Fix] TimeoutException not being caught in metric.py

### DIFF
--- a/src/math_verify/metric.py
+++ b/src/math_verify/metric.py
@@ -1,5 +1,6 @@
 ## Parser definition
 import logging
+from math_verify.errors import TimeoutException
 from math_verify.grader import verify
 from math_verify.parser import ExprExtractionConfig, ExtractionTarget, parse
 from math_verify.utils import timeout
@@ -77,7 +78,7 @@ def math_metric(
             str_preds = get_str_preds_with_timeout(
                 extracted_predictions, extracted_golds
             )
-        except Exception:
+        except TimeoutException:
             logger.warning(
                 "Timeout when adding extracted predictions and golds to specific"
             )


### PR DESCRIPTION
The `TimeoutException` raised by @timeout decorator will not be caught in the subsequent code:

[https://github.com/huggingface/Math-Verify/blob/main/src/math_verify/metric.py#L76-L83](url)

This occurs because `Exception` is a subclass of `BaseException`, and `TimeoutException` inherits directly from `BaseException` rather than `Exception`.

[https://github.com/huggingface/Math-Verify/blob/main/src/math_verify/errors.py#L1-L2](url)